### PR TITLE
setting the version to dev4

### DIFF
--- a/hazpy/__init__.py
+++ b/hazpy/__init__.py
@@ -12,7 +12,7 @@
     
 """
 
-__version__ = '0.0.2.dev5'
+__version__ = '0.0.2.dev4'
 __all__ = ['Tornado', 'Earthquake', 'Hurricane',
            'Tsunami', 'Flood', 'legacy', 'common', 'admin']
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "hazpy" %}
-{% set version = "0.0.2.dev5" %}
+{% set version = "0.0.2.dev4" %}
 
 package:
   name: "{{ name|lower }}"

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="hazpy",
-    version="0.0.2.dev5",
+    version="0.0.2.dev4",
     author="James Raines, Ujvala K Sharma",
     author_email="james.rainesii@fema.dhs.gov, usharma@niyamit.com, ujvalak_in@yahoo.com",
     description="FEMA - hazpy Open-Source Library",


### PR DESCRIPTION
setting the version to dev4 to match with the nhrap-dev conda channel package to avoid re-installs on hazpy